### PR TITLE
Support Additional_repositories field

### DIFF
--- a/buildtools/R/buildtools.R
+++ b/buildtools/R/buildtools.R
@@ -129,9 +129,14 @@ package_sysdeps_string <- maketools::package_sysdeps_string
 #' @export
 install_dependencies <- function(path = '.'){
   setwd(path)
+  desc <- as.data.frame(read.dcf('DESCRIPTION'))
+  # Additional repositories need to be considered if they aren't yet on 
+  # r-universe
+  addl <- desc$Additional_repositories
+  addl <- if (is.null(addl)) addl else strsplit(addl, ",")[[1]]
   deps <- remotes::local_package_deps(dependencies=TRUE)
-  utils::install.packages(deps)
-  remotes <- as.data.frame(read.dcf('DESCRIPTION'))$Remotes
+  utils::install.packages(deps, repos = c(addl, getOption("repos")))
+  remotes <- desc$Remotes
 
   # The following should not be needed if the remote is part of the universe
   # However we install it anyway to avoid race conditions if the remote was just added


### PR DESCRIPTION
I've modified `buildtools::install_dependencies()` to use the `Additional_repositories` field in the DESCRIPTION because i have packages in my universe that are inter dependent and previously built on my own drat repository. 

Without `Additional_repositories`, my universe falls apart: https://github.com/r-universe/carpentries/runs/2641126662?check_suite_focus=true

Help me @jeroen, you're my only hope