### PR TITLE
Add explicit origin/ to git reset

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ DEFAULT_BRANCH=$(git -C "${REPO}" branch --show-current)
 
 if [ "${2}" ]; then
 echo "Resetting to $2"
-( cd ${REPO}; git fetch origin "$2"; git reset --hard "$2" )
+( cd ${REPO}; git fetch origin "$2"; git reset --hard "origin/$2" )
 fi
 echo "::endgroup::"
 


### PR DESCRIPTION
Trying to use this manually, currently fails with
```
 * branch            RELEASE_3_20 -> FETCH_HEAD
fatal: ambiguous argument 'RELEASE_3_20': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Replicated manually below in the container, showing how the small change makes it work with branches.

```
root@0760e4747f78:/pkglib/ontoProc# git fetch origin RELEASE_3_20
From https://git.bioconductor.org/packages/ontoProc
 * branch            RELEASE_3_20 -> FETCH_HEAD
root@0760e4747f78:/pkglib/ontoProc# git reset --hard "RELEASE_3_20"
fatal: ambiguous argument 'RELEASE_3_20': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
root@0760e4747f78:/pkglib/ontoProc# git reset --hard "origin/RELEASE_3_20"
HEAD is now at 34135d3 bump x.y.z version to even y prior to creation of RELEASE_3_20 branch
```
