### PR TITLE
Accept ORCID iDs beyond the 0000 prefix

### DIFF
--- a/R/buildtools.R
+++ b/R/buildtools.R
@@ -564,7 +564,7 @@ get_maintainer_info <- function(path = '.'){
 }
 
 parse_orcid_id <- function(str){
-  pattern <- '0000-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]'
+  pattern <- '000[0-9]-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]'
   m <- regexpr(pattern, str)
   result <- regmatches(str, m)
   if(length(result)){


### PR DESCRIPTION
parse_orcid_id() only matches iDs with the 0000- prefix. ORCID has been issuing iDs in the 0009- range since 2023, so maintainers with newer iDs get orcid: null in _maintainer metadata.